### PR TITLE
Make compatible with Django 5.0+.

### DIFF
--- a/direct_cloud_upload/widgets.py
+++ b/direct_cloud_upload/widgets.py
@@ -3,8 +3,7 @@ import time
 
 from django.forms import Widget
 from django.urls import reverse
-from django.utils import baseconv
-from django.core.signing import Signer
+from django.core.signing import Signer, b62_encode
 
 signer = Signer()
 
@@ -39,7 +38,7 @@ class CloudFileWidget(Widget):
         context = super(CloudFileWidget, self).get_context(name, value, attrs)
         include_timestamp_indicator = '1' if self.include_timestamp else '0'
         allow_multiple_indicator = '1' if self.allow_multiple else '0'
-        valid_until = baseconv.base62.encode(int(time.time()) + self.submit_timeout)
+        valid_until = b62_encode(int(time.time()) + self.submit_timeout)
         to_sign = f"{self.bucket_identifier}/{self.path_prefix}:{include_timestamp_indicator}:{allow_multiple_indicator}:{valid_until}"
         context['ddcu_token'] = signer.sign(to_sign)
         context['guu_path'] = reverse('ddcu-get-upload-url')

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ classifiers =
 [options]
 python_requires = >=3.5
 install_requires =
-    Django>=2.2
+    Django>=4.0
     google-cloud-storage>=1.25
 include_package_data = true
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-direct-cloud-upload
-version = 0.3.0
+version = 0.4.0
 description = Widget for uploading files from the client directly to a cloud storage bucket.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
baseconv was deprecated in version 4.0 and removed in 5.0. The encode/decode functions can be found in djagngo.core.signing.

This updates setup.cfg to specify Django >= 4.0; if compatibility with older versions is still required then potentially we could do a conditional import.